### PR TITLE
manifest: Remove -q from repo sync command The flag -q i.e lowered ou…

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -15,7 +15,7 @@ repo init -u git://github.com/ForkLineageOS/android.git -b lineage-18.1
 ```
 Then to sync up:
 ```
-repo sync -c -q --force-sync --optimized-fetch --no-tags --no-clone-bundle --prune -j$(nproc --all)
+repo sync -c --force-sync --optimized-fetch --no-tags --no-clone-bundle --prune -j$(nproc --all)
 ```
 
 ## Finally, to build


### PR DESCRIPTION
…tput is now default behaviour and adding -q now hides all output from repo sync.

Signed-off-by: Sarthak <sarthakroy2002@gmail.com>