### PR TITLE
Fix sync error after TZDB edit

### DIFF
--- a/snippets/fork.xml
+++ b/snippets/fork.xml
@@ -47,7 +47,7 @@
   <remove-project name="LineageOS/android_packages_apps_Messaging" />
   <remove-project name="platform/external/arm-optimized-routines" />
   <remove-project name="platform/external/jemalloc_new" />
-  <remove-project name="platform/libcore" />
+  <remove-project name="LineageOS/android_libcore" />
   <remove-project name="platform/external/sqlite" />
   <remove-project name="LineageOS/android_system_logging" />
   <remove-project name="platform/system/memory/lmkd" />


### PR DESCRIPTION
This fix the error generated after changing libcore path name commit 96b8791041e0897f748dc1e8c2eaf0721d07a26a